### PR TITLE
Changed shell_exec() to the use of Symfony's Process component

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "name": "tremby/laravel-git-version",
     "description": "A helper to get the current git version of the application",
     "require": {
-        "illuminate/support": ">=4"
+        "illuminate/support": ">=4",
+        "symfony/process": ">=4"
     },
     "license": "MIT",
     "authors": [

--- a/src/GitVersionHelper.php
+++ b/src/GitVersionHelper.php
@@ -40,7 +40,7 @@ class GitVersionHelper
         chdir(base_path());
 
         // Get version string from git
-        $process = new Process(['git describe', '--always', '--tags', '--dirty']);
+        $process = new Process(['git', 'describe', '--always', '--tags', '--dirty']);
         $process->run();
         $output = $process->getOutput();
 

--- a/src/GitVersionHelper.php
+++ b/src/GitVersionHelper.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Tremby\LaravelGitVersion;
 
 use Config;

--- a/src/GitVersionHelper.php
+++ b/src/GitVersionHelper.php
@@ -40,8 +40,7 @@ class GitVersionHelper
         chdir(base_path());
 
         // Get version string from git
-        $command = 'git describe --always --tags --dirty';
-        $process = new Process($command);
+        $process = new Process(['git describe', '--always', '--tags', '--dirty']);
         $process->run();
         $output = $process->getOutput();
 

--- a/src/GitVersionHelper.php
+++ b/src/GitVersionHelper.php
@@ -1,7 +1,9 @@
 <?php
+
 namespace Tremby\LaravelGitVersion;
 
 use Config;
+use Symfony\Component\Process\Process;
 
 class GitVersionHelper
 {
@@ -39,7 +41,10 @@ class GitVersionHelper
         chdir(base_path());
 
         // Get version string from git
-        $output = shell_exec('git describe --always --tags --dirty');
+        $command = 'git describe --always --tags --dirty';
+        $process = new Process($command);
+        $process->run();
+        $output = $process->getOutput();
 
         // Change back
         chdir($dir);


### PR DESCRIPTION
Because some shared hosting servers will have exec() and shell_exec() disabled for security reasons, I have implemented Symfony's Process component.