### PR TITLE
Better symfony/process approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "illuminate/support": ">=4"
     },
     "suggest": {
-        "symfony/process": "Used rather than `shell_exec` if available (>=4)."
+        "symfony/process": "Used rather than `shell_exec` if available (>=4.2)."
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
- Suggesting symfony/process >= 4.2 (works with Laravel/Lumen 5.4+)
- Prevent errors on newer versions (symfony/process string constructor is deprecated)
- No need to chdir() when using him